### PR TITLE
Yaldong/fix appinsight panic

### DIFF
--- a/appinsights/src/channel/memory.rs
+++ b/appinsights/src/channel/memory.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use crossbeam_queue::SegQueue;
 use futures_channel::mpsc::UnboundedSender;
-use log::{debug, trace, warn};
+use log::{debug, trace, warn, error};
 use tokio::task::JoinHandle;
 
 use crate::{
@@ -51,7 +51,10 @@ impl InMemoryChannel {
         // wait until worker is finished
         if let Some(handle) = self.join.take() {
             debug!("Shutting down worker");
-            handle.await.unwrap();
+            match handle.await {
+                Ok(r) => r,
+                Err(err) => error!("Shutting down worker failed with error: {}", err)
+            }
         }
     }
 }

--- a/appinsights/src/channel/memory.rs
+++ b/appinsights/src/channel/memory.rs
@@ -42,7 +42,7 @@ impl InMemoryChannel {
         }
     }
 
-    async fn shutdown(&mut self, command: Command) {
+    async fn shutdown(mut self, command: Command) {
         // send shutdown command
         if let Some(sender) = self.command_sender.take() {
             send_command(&sender, command);
@@ -69,11 +69,11 @@ impl TelemetryChannel for InMemoryChannel {
         }
     }
 
-    async fn close(&mut self) {
+    async fn close(self) {
         self.shutdown(Command::Close).await
     }
 
-    async fn terminate(&mut self) {
+    async fn terminate(self) {
         self.shutdown(Command::Terminate).await;
     }
 }

--- a/appinsights/src/channel/mod.rs
+++ b/appinsights/src/channel/mod.rs
@@ -24,12 +24,12 @@ pub trait TelemetryChannel {
     /// Flushes and tears down the submission flow and closes internal channels.
     /// It blocks the current task until all pending telemetry items have been submitted and it is safe to
     /// shutdown without losing telemetry.
-    async fn close(&mut self);
+    async fn close(self);
 
     /// Flushes and tears down the submission flow and closes internal channels.
     /// It blocks the current task until all pending telemetry items have been submitted and it is safe to
     /// shutdown without losing telemetry.
     /// Tears down the submission flow and closes internal channels. Any telemetry waiting to be sent is discarded.
     /// This is a more abrupt version of [close](#method.close).
-    async fn terminate(&mut self);
+    async fn terminate(self);
 }

--- a/appinsights/src/client/integration_tests.rs
+++ b/appinsights/src/client/integration_tests.rs
@@ -21,7 +21,7 @@ use tokio::sync::{
     oneshot,
 };
 
-use crate::{timeout, TelemetryClient, TelemetryConfig};
+use crate::{channel::InMemoryChannel, timeout, TelemetryClient, TelemetryConfig};
 
 lazy_static! {
     /// A global lock since most tests need to run in serial.
@@ -371,7 +371,7 @@ manual_timeout_test! {
 
 // TODO Check case when all retries exhausted. Pending items should not be lost
 
-fn create_client(endpoint: &str) -> TelemetryClient {
+fn create_client(endpoint: &str) -> TelemetryClient<InMemoryChannel> {
     let config = TelemetryConfig::builder()
         .i_key("instrumentation key")
         .endpoint(endpoint)

--- a/appinsights/src/lib.rs
+++ b/appinsights/src/lib.rs
@@ -174,6 +174,7 @@
 pub mod blocking;
 
 mod channel;
+pub use channel::InMemoryChannel;
 
 mod client;
 pub use client::TelemetryClient;

--- a/appinsights/src/transmitter.rs
+++ b/appinsights/src/transmitter.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 use http::{header::RETRY_AFTER, StatusCode};
-use log::debug;
+use log::{debug, trace};
 use reqwest::Client;
 
 use crate::{
@@ -122,7 +122,12 @@ fn retain_retry_items(items: &mut Vec<Envelope>, content: Transmission) {
     let mut errors = content.errors.iter().filter(|error| can_retry_item(error)).collect::<Vec<_>>();
     errors.sort_by_key(|error| error.index); // Fix panic 'removal index (is 0) should be < len (is 0)'
     for error in errors {
-        retry_items.push(items.remove(error.index - retry_items.len()));
+        let remove_index = error.index - retry_items.len();
+        if remove_index < items.len() {
+            retry_items.push(items.remove(remove_index));
+        } else {
+            trace!("Skipping add retry item since error.index: {}, items.len: {}", error.index, items.len())
+        }
     }
 
     *items = retry_items;

--- a/appinsights/src/transmitter.rs
+++ b/appinsights/src/transmitter.rs
@@ -119,7 +119,9 @@ impl Transmitter {
 /// Filters out those telemetry items that cannot be re-sent.
 fn retain_retry_items(items: &mut Vec<Envelope>, content: Transmission) {
     let mut retry_items = Vec::default();
-    for error in content.errors.iter().filter(|error| can_retry_item(error)) {
+    let mut errors = content.errors.iter().filter(|error| can_retry_item(error)).collect::<Vec<_>>();
+    errors.sort_by_key(|error| error.index); // Fix panic 'removal index (is 0) should be < len (is 0)'
+    for error in errors {
         retry_items.push(items.remove(error.index - retry_items.len()));
     }
 


### PR DESCRIPTION
Fix those panics:

9a42c289f46543d1992c488544be15bd-hosttools-capability stderr logs: 2022-11-08T23:54:47.236679773Z thread 'tokio-runtime-worker' panicked at 'removal index (is 0) should be < len (is 0)', /usr/local/cargo/git/checkouts/appinsights-rs-dead6b7ee03fa1a1/a0057e0/appinsights/src/transmitter.rs:125:32

9a42c289f46543d1992c488544be15bd-hosttools-capability stderr logs: 2022-11-09T00:16:43.824433955Z thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: JoinError::Panic(Id(5), ...)', /usr/local/cargo/git/checkouts/appinsights-rs-dead6b7ee03fa1a1/a0057e0/appinsights/src/channel/memory.rs:54:26
